### PR TITLE
adding skipLibCheck

### DIFF
--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "dist",
     "strict": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]


### PR DESCRIPTION
[Our emotion tracker](https://github.com/HASEL-UZH/PA.EmotionsTrackerClient/) uses tfjs-node. For its installation, skipLibCheck is needed (see [here](https://www.tensorflow.org/js/tutorials/setup#typescript)). 

Do you see any downside in adding this to `tsconfig.json`?

@casaout @bugii who is the current maintainer of this repo? :) 